### PR TITLE
add PyYAML requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fusepy==2.0.4
 PyHamcrest==1.8.5
 python-myna==1.1.0
+PyYAML==3.11


### PR DESCRIPTION
Fixes this error when installing from source as suggested in the README:

```
$ python kubefuse/kubefuse.py ~/k8s
Traceback (most recent call last):
  File "kubefuse/kubefuse.py", line 10, in <module>
    from client import KubernetesClient
  File "/Users/matt/Projects/kubefuse/kubefuse/client.py", line 2, in <module>
    import yaml
ImportError: No module named yaml
```

After adding PyYAML, I'm able to run kubefuse fine in a virtualenv with python2.7.

Refs #6.
