### PR TITLE
[WIP] Add unlink/rmdir. Fixes #7

### DIFF
--- a/kubefuse/cache.py
+++ b/kubefuse/cache.py
@@ -25,5 +25,8 @@ class ExpiringCache(object):
         return None
 
     def delete(self, key):
-        del(self._timestamps[key])
-        del(self._cache[key])
+        try:
+            del(self._timestamps[key])
+            del(self._cache[key])
+        except KeyError:
+            pass

--- a/kubefuse/client.py
+++ b/kubefuse/client.py
@@ -1,8 +1,11 @@
+import logging
 import subprocess
 import yaml
 import tempfile
 
 from cache import ExpiringCache
+
+LOGGER = logging.getLogger(__name__)
 
 class KubernetesClient(object):
     def __init__(self):
@@ -24,16 +27,30 @@ class KubernetesClient(object):
         result = func()
         self._cache.set(key, result)
         return result
-        
+
     def get_namespaces(self):
         key = "namespaces"
         cb = self._get_namespaces
         return self._load_from_cache_or_do(key, cb)
 
+    def delete_namespace(self, namespace):
+        LOGGER.info(self._run_command(('delete namespace ' + namespace).split()))
+        self._cache.delete('namespaces')
+
     def get_entities(self, ns, entity):
         key = "%s.%s" % (ns, entity)
         cb = lambda: self._get_entities(ns,entity)
         return self._load_from_cache_or_do(key, cb)
+
+    def delete_entities(self, ns, entity_type):
+        key = "%s.%s" % (ns, entity_type)
+        LOGGER.info(self._run_command(("delete %s --all " % entity_type).split() + self._namespace(ns)))
+        self._cache.delete(key)
+
+    def delete_entity(self, ns, entity_type, object_name):
+        key = "%s.%s" % (ns, entity_type)
+        LOGGER.info(self._run_command(("delete %s %s " % (entity_type, object_name)).split() + self._namespace(ns)))
+        self._cache.delete(key)
 
     def get_object_in_format(self, ns, entity_type, object, format):
         key = "%s.%s.%s.%s" % (ns, entity_type, object, format)

--- a/kubefuse/kubefuse.py
+++ b/kubefuse/kubefuse.py
@@ -25,6 +25,12 @@ class KubeFuse(LoggingMixIn, Operations):
     def getattr(self, path, fh=None):
         return self.fs.getattr(path)
 
+    def rmdir(self, path):
+        return self.fs.rmdir(path)
+
+    def unlink(self, path):
+        return self.fs.unlink(path)
+
     def open(self, path, fh):
         self.fd += 1
         self.fs.open(path, fh)


### PR DESCRIPTION
Here's an initial implementation of unlink/rmdir.
Seems to work locally (I've tested deleting namespaces, individual pods, and all pods in a namespace), but I haven't started writing tests etc yet.

`rm -rf` ends up being very slow, as it ends up populating the cache of everything underneath it, and it starts going a big wonky when it tries to delete nodes etc..
`rmdir` is nice and quick, and works as expected
