### PR TITLE
Fix on mac OSX with python 3

### DIFF
--- a/kubefuse/client.py
+++ b/kubefuse/client.py
@@ -3,7 +3,7 @@ import yaml
 import tempfile
 import six
 
-from . import cache
+import cache
 
 
 class KubernetesClient(object):

--- a/kubefuse/filesystem.py
+++ b/kubefuse/filesystem.py
@@ -3,7 +3,7 @@ from time import time
 import logging
 import errno
 from fuse import FuseOSError
-from . import path 
+import path 
 KubePath = path.KubePath
 
 logger = logging.getLogger(__name__)

--- a/kubefuse/kubefuse.py
+++ b/kubefuse/kubefuse.py
@@ -12,8 +12,8 @@ except EnvironmentError:
     sys.exit(1)
 
 
-from . import client
-from . import filesystem
+import client
+import filesystem
 
 
 class KubeFuse(LoggingMixIn, Operations):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fusepy==2.0.4
 PyHamcrest==1.8.5
 python-myna==1.2.0
-PyYAML==3.11
+PyYAML==5.4.1
 six==1.10.0
 nose


### PR DESCRIPTION
I had some problems to get this library work on mac osx with python 3, those are changes I had to do:

1. PyYAML had bug in 3.* versions that prevent it from install on mac, i upgraded to newest
2. Unable to run it as described in documentation, got some veird errors that parent module does not exists, had to rewrite those imports

I did not tried to run unit tests